### PR TITLE
Use bounded channels for server

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,13 +7,16 @@ use warp::{ws::Message, Filter};
 pub mod handler;
 pub mod ws;
 
+/// The buffer size for `mpsc::channel`s for client connections
+pub const CLIENT_CONN_SIZE: usize = 42;
+
 /// A Client
 #[derive(Debug, Clone)]
 pub struct Client {
     /// The client's UUID
     pub client_id: String,
     /// Communication channel sender end
-    pub sender: Option<mpsc::UnboundedSender<Result<Message, warp::Error>>>,
+    pub sender: Option<mpsc::Sender<Result<Message, warp::Error>>>,
 }
 
 /// A list of registered clients keyed by UUIDs

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -2,25 +2,24 @@
 
 use futures::{FutureExt, StreamExt};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 use warp::ws::{Message, WebSocket};
 
 use super::Client;
 use super::Clients;
+use super::CLIENT_CONN_SIZE;
 
 /// Registers a new client, communicates with it and removes it afterwards.
 ///
 /// The actual message handling is done by `client_msg`.
-///
-/// TODO: Using unbounded channels may be not the best choice, because we may run out of memory.
 pub async fn client_connection(ws: WebSocket, clients: Clients) {
     println!("Established client connection: {:?}", ws);
 
     // Setup the communication channel.
     let (client_ws_sender, mut client_ws_rcv) = ws.split();
-    let (client_sender, client_rcv) = mpsc::unbounded_channel();
-    let client_rcv = UnboundedReceiverStream::new(client_rcv);
+    let (client_sender, client_rcv) = mpsc::channel(CLIENT_CONN_SIZE);
+    let client_rcv = ReceiverStream::new(client_rcv);
 
     // Keep the stream running.
     tokio::task::spawn(client_rcv.forward(client_ws_sender).map(|result| {
@@ -89,7 +88,7 @@ async fn client_msg(client_id: &str, msg: Message, clients: &Clients) -> bool {
         Some(v) => {
             if let Some(sender) = &v.sender {
                 println!("sending echo message");
-                let _ = sender.send(Ok(Message::text(message)));
+                let _ = sender.send(Ok(Message::text(message))).await;
             }
         }
         None => return true,


### PR DESCRIPTION
Using unbounded channels may open doors for DOS attacks.
Switch to bounded channels.